### PR TITLE
sh would fail to run the scriptis on KDE neon

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ me by telegram: [@supremoh](https://t.me/supremoh).
 
 Download the package, extract it and run the following command to **install** this Dolphin Service. 
 
-    sh ./install.sh
+    ./install.sh
 
 If you don't like it, you can **uninstall** it by running:
 
-    sh ./uninstall.sh
+    ./uninstall.sh
 
 ## Usage
 

--- a/TemplateManager.desktop
+++ b/TemplateManager.desktop
@@ -29,7 +29,7 @@ Name[pt]=Criar modelo...
 Name[ru]=Создать шаблон...
 Name[nl]=Sjabloon maken…
 Icon=xapp-favorite-symbolic
-Exec=sh $HOME/.bin/TemplateCreator.sh %f
+Exec=$HOME/.bin/TemplateCreator.sh %f
 
 [Desktop Action TemplateEraser]
 Name=Remove existing template(s)
@@ -41,4 +41,4 @@ Name[pt]=Remover modelo(s) existente(s)
 Name[ru]=Удалить существующие шаблон(ы)
 Name[nl]=Gemaakte sjablonen verwijderen
 Icon=delete
-Exec=sh $HOME/.bin/TemplateEraser.sh
+Exec=$HOME/.bin/TemplateEraser.sh


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10415894/121705202-b4cad000-cad4-11eb-8242-3e6bee72cc18.png)

Actually needs bash to execute the scripts.
sh would fail on my desktop and the extension would not work.

As they are executable, sh is not necessary there. Otherwise you could replace sh with bash in these lines.