### PR TITLE
Do not hardcode path to templates folder

### DIFF
--- a/TemplateManagerTools.sh
+++ b/TemplateManagerTools.sh
@@ -4,8 +4,8 @@ creator_icon="xapp-favorite-symbolic"
 editor_icon="edit"
 eraser_icon="delete"
 
-template_folder="$HOME/Templates"
-template_src_folder="$HOME/Templates/source"
+template_folder="$(xdg-user-dir TEMPLATES)" # Alternatively, place to one of the folders in kf5-config --path templates
+template_src_folder="$(xdg-user-dir TEMPLATES)/source"
 
 desktop_ext=".desktop"
 


### PR DESCRIPTION
I had my XDG_TEMPLATES_DIR different from "$HOME/Templates", so adding templates had no effect in dolphin.
I have replaced hardcoded assumption of path to the path set by user.