### PR TITLE
Do not use top level to keep main menu clean

### DIFF
--- a/TemplateManager.desktop
+++ b/TemplateManager.desktop
@@ -28,7 +28,6 @@ ServiceTypes=KonqPopupMenu/Plugin;
 X-KDE-ServiceTypes=KonqPopupMenu/Plugin
 MimeType=all/allfiles;inode/directory;
 Actions=TemplateCreator;TemplateEditor;TemplateEraser;
-X-KDE-Priority=TopLevel
 X-KDE-StartupNotify=false
 X-KDE-Submenu=Manage template(s)
 X-KDE-Submenu[es]=Gestionar plantilla(s)


### PR DESCRIPTION
I suggest to not use TopLevel menu, because it clutters it. This action is not _such_ often, so it may reside in Actions -> Manage template(s).